### PR TITLE
Add REFUTE (scientific critique & epistemic calibration)

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Although the knowledge boundary is important for knowledge-intensive tasks, ther
 ## 👻 Hallucination & Factuality
 
 ### Hallucination Detection
+- **[REFUTE](https://bgpt.pro/refute)** — Scientific critique & epistemic calibration. Judge-free board for whether models overclaim on recent science summaries; critique skill ≠ calibration. [Dataset](https://huggingface.co/datasets/BGPT-OFFICIAL/refute)
 
 #### Consistency-based Detection
 


### PR DESCRIPTION
Adds REFUTE under hallucination/factuality resources.

Useful neighbor to reliability lists: strongest-looking critics can still be poorly calibrated on recent science summaries.

https://bgpt.pro/refute